### PR TITLE
YouTube desc and link updated

### DIFF
--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -184,19 +184,19 @@ const About = ({ theme }) => {
               </ul>
             </p>
             <p>
-              See also the
+              See the LF Networking
               <span>
                 <a
                   target="_blank"
                   rel="noopener noreferrer"
-                  href="https://www.youtube.com/user/opendaylightproject"
+                  href="https://www.youtube.com/@lfnetworking"
                   className="link"
                 >
                   {' '}
                   YouTube channel{' '}
                 </a>
               </span>
-              for other tutorials.
+              for the latest videos from our Developer Events!
             </p>
           </div>
           <div className="training-image flex justify-center">


### PR DESCRIPTION
This PR changes the YouTube desc and updates the channel link in the About Page.